### PR TITLE
Adding period after script tag for jade > v0.31.0

### DIFF
--- a/client/views/index.jade
+++ b/client/views/index.jade
@@ -8,7 +8,7 @@ html(lang='en', data-ng-app='angular-client-side-auth')
         link(href="//netdna.bootstrapcdn.com/font-awesome/3.1.1/css/font-awesome.min.css", rel="stylesheet")
 
         // This is needed because Facebook login redirects add #_=_ at the end of the URL
-        script(type="text/javascript")
+        script(type="text/javascript").
             if (window.location.href.indexOf('#_=_') > 0) {
                 window.location = window.location.href.replace(/#.*/, '');
             }


### PR DESCRIPTION
Fixes error msg: "Implicit textOnly for `script` and `style` is deprecated.  Use `script.` or `style.` instead."

Altternative fix would be to pin jade to previous version (0.30.0 - not tested though).
