### PR TITLE
Delete cookie removal

### DIFF
--- a/client/js/services.js
+++ b/client/js/services.js
@@ -7,7 +7,6 @@ angular.module('angular-client-side-auth')
         , userRoles = routingConfig.userRoles
         , currentUser = $cookieStore.get('user') || { username: '', role: userRoles.public };
 
-    $cookieStore.remove('user');
 
     function changeUser(user) {
         _.extend(currentUser, user);


### PR DESCRIPTION
Delete user Cookie Removal since it is handled by Passport from the backend and it really does not delete the user cookie.
