### PR TITLE
removes underscore dependency for client

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,6 @@
     "angular-ui-router": "0.2.8-bowratic-tedium",
     "bootstrap": "~3.1.0",
     "font-awesome": "~4.0.3",
-    "underscore": "~1.5.2",
     "angular-cookies": "~1.2.12"
   },
   "devDependencies": {

--- a/client/js/services.js
+++ b/client/js/services.js
@@ -10,7 +10,7 @@ angular.module('angular-client-side-auth')
     $cookieStore.remove('user');
 
     function changeUser(user) {
-        _.extend(currentUser, user);
+        angular.extend(currentUser, user);
     };
 
     return {

--- a/client/tests/unit/servicesSpec.js
+++ b/client/tests/unit/servicesSpec.js
@@ -31,42 +31,42 @@ describe('services', function() {
     describe('instantiate', function() {
       it('should have isLoggedIn function', function() {
         expect(Auth.isLoggedIn).to.not.be.undefined;
-        expect(_.isFunction(Auth.isLoggedIn)).to.equal(true);
+        expect(angular.isFunction(Auth.isLoggedIn)).to.equal(true);
       });
 
       it('should have authorize function', function() {
         expect(Auth.authorize).to.not.be.undefined;
-        expect(_.isFunction(Auth.authorize)).to.equal(true);
+        expect(angular.isFunction(Auth.authorize)).to.equal(true);
       });
 
       it('should have login function', function() {
         expect(Auth.login).to.not.be.undefined;
-        expect(_.isFunction(Auth.login)).to.equal(true);
+        expect(angular.isFunction(Auth.login)).to.equal(true);
       });
 
       it('should have logout function', function() {
         expect(Auth.logout).to.not.be.undefined;
-        expect(_.isFunction(Auth.logout)).to.equal(true);
+        expect(angular.isFunction(Auth.logout)).to.equal(true);
       });
 
       it('should have register function', function() {
         expect(Auth.register).to.not.be.undefined;
-        expect(_.isFunction(Auth.register)).to.equal(true);
+        expect(angular.isFunction(Auth.register)).to.equal(true);
       });
 
       it('should have the user object', function() {
         expect(Auth.user).to.not.be.undefined;
-        expect(_.isObject(Auth.user)).to.equal(true);
+        expect(angular.isObject(Auth.user)).to.equal(true);
       });
 
       it('should have the userRoles object', function() {
         expect(Auth.userRoles).to.not.be.undefined;
-        expect(_.isObject(Auth.userRoles)).to.equal(true);
+        expect(angular.isObject(Auth.userRoles)).to.equal(true);
       });
 
       it('should have the accessLevels object', function() {
         expect(Auth.accessLevels).to.not.be.undefined;
-        expect(_.isObject(Auth.accessLevels)).to.equal(true);
+        expect(angular.isObject(Auth.accessLevels)).to.equal(true);
       });
 
       it('should set the user object with no name and public role', function() {


### PR DESCRIPTION
references https://github.com/fnakstad/angular-client-side-auth/issues/63

You only use underscore very few times on the client side. Angular has equivalent functions built in. Why not remove the underscore dependency?
